### PR TITLE
Add a Tools page to Hy docs

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -673,3 +673,22 @@ Which, of course, expands out to:
     (wc (grep (cat "/usr/share/dict/words") "-E" "^hy") "-l")
 
 Much more readable, no? Use the threading macro!
+
+
+
+Tools
+=====
+
+Here are useful tools to work with Hy.
+
+**Editor plugins:**
+
+* Vim-hy for Vim
+* Hy-mode for Emacs
+* Hy kernel for Jupyter
+* Hy plugin for Sublime
+
+**Other:**
+
+* Hy debugger
+* Hy code analyzer


### PR DESCRIPTION
Aim: solve issue #743 
-> new page in the docs called "Tools" with a list of tools and explanation on installation/use
-> cross link this page to the Tutorial and Quickstart

Status: new "Tools" section within the tutorial page
